### PR TITLE
Add Sunday Times spider

### DIFF
--- a/scrapenews/spiders/sundaytimes.py
+++ b/scrapenews/spiders/sundaytimes.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+
+from scrapenews.spiders.timeslive import TimesliveSpider
+
+
+class SundayTimesSpider(TimesliveSpider):
+    """
+    Class implementing a sitemap spider for the Sunday Times (https://www.timeslive.co.za/sunday-times/).
+    The Sunday Times is hosted on the TimesLIVE website (https://www.timeslive.co.za).
+    This spider is therefore implemented as a subclass of the TimesLIVE spider but only parsing paths that contain `/sunday-times/`.
+    """
+
+    name = 'sundaytimes'
+
+    sitemap_rules = [('/sunday-times/', 'parse')]
+
+    publication_name = 'Sunday Times'


### PR DESCRIPTION
This pull request adds a spider for the [Sunday Times](https://www.timeslive.co.za/sunday-times/) as per the [Sunday Times scraper](https://trello.com/c/5dL5FHE0/77-sunday-times-scraper) card on the [Public People](https://trello.com/b/9TVRB4gb/public-people) Trello board.

The Sunday Times is hosted on the TimesLIVE website, with `https://sundaytimes.co.za` redirecting to `https://www.timeslive.co.za/sunday-times/`.

All of the Sunday Times articles appear to have `https://www.timeslive.co.za/sunday-times/` as the base URL. The articles can be found through the standard TimesLIVE sitemap. For example, the `https://www.timeslive.co.za/sitemap/business/` sitemap entry has the following Sunday Times articles:

- `http://www.timeslive.co.za/sunday-times/business/2020-04-04-markets-look-to-wall-street-for-recovery/`
- `http://www.timeslive.co.za/sunday-times/business/2018-10-24-saa-post-office-and-other-ailing-soes-to-receive-billions-in-cash-bailouts/`
- `http://www.timeslive.co.za/sunday-times/business/2018-09-29-maverick-musk-faces-us-regulators-wrath--for---go-private-tweet/`

The `SundayTimesSpider` class is therefore implemented as a sub-class of the [`TimesliveSpider`](https://github.com/public-people/scrape-news/blob/master/scrapenews/spiders/timeslive.py) class but only parsing paths that contain `/sunday-times/`.

This is my first time working on this project as well as with [Scrapy](https://scrapy.org), so please let me know if I have missed something.