### PR TITLE
Merge py3-upgrade into master 

### DIFF
--- a/.env
+++ b/.env
@@ -1,2 +1,2 @@
-# For linting, allow imports from project root, app directory venv.
+# For linting, allow imports from project root, app directory and venv.
 PYTHONPATH=$PWD:scrapenews:venv

--- a/.env
+++ b/.env
@@ -1,1 +1,2 @@
-PYTHONPATH=scrapenews:venv
+# For linting, allow imports from project root, app directory venv.
+PYTHONPATH=$PWD:scrapenews:venv

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -14,13 +14,12 @@ jobs:
       with:
         python-version: 2.7
     - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install -r requirements.txt
+      run: make install
+    - name: Unit tests
+      run: make unit
+    - name: Install test dependencies
+      run: make dev-install
     - name: Lint with flake8
-      run: |
-        pip install flake8
-        # stop the build if there are Python syntax errors or undefined names
-        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+      run: make lint
+    - name: Lint for PY3 compatibility
+      run: make lint-py3

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -6,13 +6,15 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python: ["3.5", "3.x"]
+    name: Python ${{ matrix.python }} sample
 
     steps:
     - uses: actions/checkout@v1
-    - name: Set up Python 2.7
+    - name: Set up Python
       uses: actions/setup-python@v1
-      with:
-        python-version: 2.7
     - name: Install dependencies
       run: make install
     - name: Unit tests

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -23,5 +23,3 @@ jobs:
       run: make dev-install
     - name: Lint with flake8
       run: make lint
-    - name: Lint for PY3 compatibility
-      run: make lint-py3

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,4 @@
 {
-    "terminal.integrated.cwd": "scrapenews",
-    "code-runner.cwd": "scrapenews",
-
     "python.pythonPath": "venv/bin/python",
 
     "editor.rulers": [

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 help:
 	@egrep '^\w*:' Makefile
 
-mkenv:
+new-env:
 	# Use the venv builtin module to create a virtual environment also called venv.
 	python3 -m venv venv
 

--- a/Makefile
+++ b/Makefile
@@ -30,5 +30,5 @@ test-iol:
 	# Note that is works from the project root because of how scrapy runs.
 	scrapy crawl iol -s ITEM_PIPELINES="{}" -a since_lastmod=2018-01-01
 
-spiders:
+list:
 	scrapenews/utils/list_spiders.py

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 help:
-	@egrep '^\w*:' Makefile
+	@egrep '.*:$$' Makefile
 
 new-env:
 	# Use the venv builtin module to create a virtual environment also called venv.

--- a/Makefile
+++ b/Makefile
@@ -29,3 +29,6 @@ test-iol:
 	# Test a certain crawler without using the upload pipeline.
 	# Note that is works from the project root because of how scrapy runs.
 	scrapy crawl iol -s ITEM_PIPELINES="{}" -a since_lastmod=2018-01-01
+
+spiders:
+	scrapenews/utils/list_spiders.py

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 help:
-	@egrep '.*:$$' Makefile
+	@egrep '^\w+' Makefile
 
 new-env:
 	# Use the venv builtin module to create a virtual environment also called venv.

--- a/Makefile
+++ b/Makefile
@@ -18,10 +18,6 @@ lint:
 	# Exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
 	flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics --exclude setup.py,scrapenews/settings.py
 
-lint-py3:
-	# Check for PY3 compatibility.
-	pylint --py3k scrapenews
-
 unit:
 	python -m unittest discover -s scrapenews/tests/unit -t scrapenews
 

--- a/Makefile
+++ b/Makefile
@@ -22,9 +22,10 @@ unit:
 	python -m unittest discover -s scrapenews/tests/unit -t scrapenews
 
 test-iol:
-	# Test a certain crawler without using the upload pipeline.
-	# Note that is works from the project root because of how scrapy runs.
-	scrapy crawl iol -s ITEM_PIPELINES="{}" -a since_lastmod=2018-01-01
+	scrapy crawl -s ITEM_PIPELINES="{}" -a since_lastmod=2018-01-01 iol
+
+test-help:
+	@echo 'scrapy crawl -s ITEM_PIPELINES="{}" -a since_lastmod=2018-01-01 <CRAWLER>'
 
 list:
-	scrapenews/utils/list_spiders.py
+	@scrapenews/utils/list_spiders.py

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ unit:
 test-iol:
 	scrapy crawl -s ITEM_PIPELINES="{}" -a since_lastmod=2018-01-01 iol
 
-test-help:
+quickstart:
 	@echo 'scrapy crawl -s ITEM_PIPELINES="{}" -a since_lastmod=2018-01-01 <CRAWLER>'
 
 list:

--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ We do not make news content available for public consumption. We simply store an
 ## Requirements
 
 - Python 3.5+
-- Python virtual environment with packages installed from [requirements.txt](/requirements.txt). This main library used [Scrapy](https://pypi.org/project/Scrapy/).
-- Setup _scrapyd_ (optional).
+- Python virtual environment with packages installed from [requirements.txt](/requirements.txt). This main library used [Scrapy](https://scrapy.org/).
+- Setup [scrapyd](https://scrapyd.readthedocs.io/en/stable/) (optional).
 - Aleph account and credentials for uploading results (optional).
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ We need very broad coverage of news outlets. Contributed spiders are very welcom
 
 It's really easy to contribute spiders. Basically you can copy an existing spider and change the xpaths to find the elements we're extracting.
 
-See the In Progress column at [https://trello.com/b/9TVRB4gb/public-people](https://trello.com/b/9TVRB4gb/public-people) to see which publications are currently being tackled to avoid duplication.
+See the _In Progress_ column at [https://trello.com/b/9TVRB4gb/public-people](https://trello.com/b/9TVRB4gb/public-people) to see which publications are currently being tackled to avoid duplication.
 
 Next, go get started at [Development](#development)
 
@@ -51,6 +51,9 @@ $ cd <PATH_TO_REPO>
 ```
 
 ### Setup virtual environment
+
+The shortcut commands used in this doc come from the [Makefile](/Makefile) and can be run from the project root using the `make` command, as below.
+
 
 1. Create a virtual environment called `venv`.
     ```bash

--- a/README.md
+++ b/README.md
@@ -50,10 +50,17 @@ Navigate to the repo.
 $ cd <PATH_TO_REPO>
 ```
 
+### Make commands
+
+This project comes with a [Makefile](/Makefile), to run with `make` command. Run the following without any arguments to get a list of available commands.
+
+```bash
+$ make
+```
+
+We'll use some of those below.
+
 ### Setup virtual environment
-
-The shortcut commands used in this doc come from the [Makefile](/Makefile) and can be run from the project root using the `make` command, as below.
-
 
 1. Create a virtual environment called `venv`.
     ```bash

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ $ cd <PATH_TO_REPO>
     $ make dev-install
     ```
 
-#### Run
+### Run
 
 Note: Always activate the project's environment before using it.
 
@@ -70,12 +70,11 @@ Note: Always activate the project's environment before using it.
 $ source venv/bin/activate
 ```
 
-##### List available spiders in the project
-
+#### List available spiders in the project
 
 ```bash
 $ make list
-scrapenews/utils/list_spiders.py # This is script you just ran.
+scrapenews/utils/list_spiders.py  # This is the script you just ran through make.
 businesslivecrawl
 businesslivesitemap
 dailymaverick
@@ -97,7 +96,7 @@ timeslive
 
 We will use these crawler names in the next step. Note that these names are generated from _classes_ in the [spiders](/scrapenews/spiders/) directory and not the _filenames_.
 
-##### Run scraper
+#### Run scraper
 
 Run a scraper using the command below to check that your environment is working properly. This can be done from the project root because of how the `scrapy` library works.
 
@@ -109,7 +108,13 @@ $ scrapy crawl iol -s ITEM_PIPELINES="{}" -a since_lastmod=2018-04-30
 - The setting `ITEM_PIPELINES` disables the pipeline we have configured which you don't need for just developing a spider.
 - The argument `since_lastmod` is the earliest sitemap file and page the scraper will include.
 
-##### Output
+For quick testing on just this one spider, a shortcut for the above command has been added to the [Makefile](/Makefile). Use it like this:
+
+```bash
+$ make test-iol
+```
+
+#### Output
 
 If it's working correctly, it will output a lot of information:
 
@@ -138,6 +143,28 @@ when it reaches articles that are after the earliest accepted date, it will actu
  'title': u'Stanlib may further reduce fund offering',
  'url': 'https://www.iol.co.za/personal-finance/stanlib-may-further-reduce-fund-offering-14717297'}
 ```
+
+
+### Code checks
+
+To maintain Python code quality, **linting** and **unit tests** should be run locally and on Github. Linting give you style warnings. The unit tests are in the [unit](/tests/unit) directory and run tests against the project code.
+
+#### Local
+
+Run the checks locally using the following commands:
+
+```bash
+$ make lint
+```
+
+```bash
+$ make unit
+```
+
+#### Github
+
+Linting and tests areas are run automatically on Github Actions when you do a push using the [Python workflow](/.github/workflows/pythonapp.yml) config. View the results on a Github repo under the _Actions_ tab.
+
 
 ### Make a spider
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ $ cd <PATH_TO_REPO>
 
 ### Make commands
 
-This project comes with a [Makefile](/Makefile), to run with `make` command. Run the following without any arguments to get a list of available commands.
+This project comes with a [Makefile](/Makefile), to run with `make` command.
 
 ```bash
 $ make

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ git clone https://github.com/your-name/scrape-news.git
 or
 
 ```bash
-$ git clone git@github.com:your-name/scrape-news.git
+git clone git@github.com:your-name/scrape-news.git
 ```
 
 (Make sure to replace ```your-name```.)

--- a/README.md
+++ b/README.md
@@ -81,7 +81,6 @@ $ source venv/bin/activate
 
 ```bash
 $ make list
-scrapenews/utils/list_spiders.py  # This is the script you just ran through make.
 businesslivecrawl
 businesslivesitemap
 dailymaverick

--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ To test individual xpath or css responses you can use the scrapy shell:
 scrapy shell "https://www.newssite.co.za/article-url"
 ```
 
-If you go to the same url in your browser and right-click on, say, the title of the article, and select 'Inspect Element (Q)', you'll see something like this highlighted.
+If you go to the same url in your browser and right-click on, say, the title of the article, and select 'Inspect Element (Q)', you'll see something like this highlighted:
 
 ```html
 <h1 class="article-title">Title of article</h1>

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ Run a scraper using the command below to check that your environment is working 
 If you need to get a template crawl command quickly and then fill in with a crawler, run the following and then copy and paste the result to a new line.
 
 ```bash
-$ make test-help
+$ make quickstart
 scrapy crawl -s ITEM_PIPELINES="{}" -a since_lastmod=2018-01-01 <CRAWLER>
 ```
 

--- a/README.md
+++ b/README.md
@@ -109,25 +109,29 @@ We will use these crawler names in the next step. Note that these names are gene
 
 Run a scraper using the command below to check that your environment is working properly. This can be done from the project root because of how the `scrapy` library works.
 
+If you need to get a template crawl command quickly and then fill in with a crawler, run the following and then copy and paste the result to a new line.
+
+```bash
+$ make test-help
+scrapy crawl -s ITEM_PIPELINES="{}" -a since_lastmod=2018-01-01 <CRAWLER>
+```
+
+For example, run the command using the _iol_ spider.
+
 ```bash
 $ scrapy crawl -s ITEM_PIPELINES="{}" -a since_lastmod=2018-04-30 iol
 ```
+
+The arguments for the above command are required. Here is how to use them:
 
 - The setting `ITEM_PIPELINES` disables the pipeline we have configured which you don't need for just developing a spider.
 - The argument `since_lastmod` is the earliest sitemap file and page the scraper will include.
 - The last argument `crawl` is the name of the scraper (e.g. `iol`). See output from the previous section.
 
-For quick testing on just this one spider, a shortcut for the above command has been added to the [Makefile](/Makefile). Use it like this:
+For quick testing on the _iol_ spider, a shortcut for the above command has been added to the [Makefile](/Makefile).
 
 ```bash
 $ make test-iol
-```
-
-Also, if you need to get a template crawl command quickly and then fill in with a crawler, run the following and then copy and paste the result to a new line.
-
-```bash
-$ make test-help
-scrapy crawl -s ITEM_PIPELINES="{}" -a since_lastmod=2018-01-01 <CRAWLER>
 ```
 
 #### Output
@@ -136,7 +140,7 @@ If the crawl command is working correctly, it will output a lot of information.
 
 e.g. after starting up it will find the sitemap and some articles that it will ignore in the sitemaps.
 
-Sample output for _iol_ crawler.
+Sample output for _iol_ crawler:
 ```
 2018-05-03 18:21:17 [scrapy.core.engine] DEBUG: Crawled (200) <GET https://www.iol.co.za/robots.txt> (referer: None) ['cached']
 2018-05-03 18:21:17 [scrapy.core.engine] DEBUG: Crawled (200) <GET https://www.iol.co.za/sitemap.xml> (referer: https://www.iol.co.za/robots.txt) ['cached']

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ We do not make news content available for public consumption. We simply store an
 Fork this repository on GitHub and clone your fork:
 
 ```bash
-$ git clone https://github.com/your-name/scrape-news.git
+git clone https://github.com/your-name/scrape-news.git
 ```
 or
 

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ The arguments for the above command are required. Here is how to use them:
 
 - The setting `ITEM_PIPELINES="{}"` disables the default pipeline we which you don't need for just developing a spider.
 - The argument `since_lastmod` is the earliest sitemap file and page the scraper will include.
-- The last argument `crawl` is the name of the scraper (e.g. `iol`). See output from the previous section.
+- The last argument to the `crawl` command is the name of the scraper (e.g. `iol`). See output from the previous section.
 
 For quick testing on the _iol_ spider, a shortcut for the above command has been added to the [Makefile](/Makefile).
 

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ We will use these crawler names in the next step. Note that these names are gene
 
 ##### Run scraper
 
-Run a scraper using the command below to check that your environment is working properly. Note that this _can_ be done from the root directory because of how the `scrapy` library works.
+Run a scraper using the command below to check that your environment is working properly. This can be done from the project root because of how the `scrapy` library works.
 
 ```bash
 $ scrapy crawl iol -s ITEM_PIPELINES="{}" -a since_lastmod=2018-04-30

--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ when it reaches articles that are after the earliest accepted date, it will actu
 
 ### Code checks
 
-To maintain Python code quality, **linting** and **unit tests** should be run locally and on Github. Linting give you style warnings. The unit tests are in the [unit](/tests/unit) directory and run tests against the project code.
+To maintain Python code quality, **linting** and **unit tests** should be run locally and in Continuous Integration. Linting give you style warnings. The unit tests are in the [unit](/tests/unit) directory and run tests against the project code.
 
 #### Local
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,13 @@ Next, go get started at [Development](#development)
 
 We do not make news content available for public consumption. We simply store and index the news content and the original URL and publication date to provide search functionality similar to search engines. This project intends to provide better access to news on the publisher's website. It should be used to send readers to relevant news websites rather than to replace them.
 
+## Requirements
+
+- Python 3.5+
+- Python virtual environment with packages installed from [requirements.txt](/requirements.txt). This main library used [Scrapy](https://pypi.org/project/Scrapy/).
+- Setup _scrapyd_ (optional).
+- Aleph account and credentials for uploading results (optional).
+
 ## Development
 
 ### Set up your development environment

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ $ scrapy crawl -s ITEM_PIPELINES="{}" -a since_lastmod=2018-04-30 iol
 
 The arguments for the above command are required. Here is how to use them:
 
-- The setting `ITEM_PIPELINES` disables the pipeline we have configured which you don't need for just developing a spider.
+- The setting `ITEM_PIPELINES="{}"` disables the default pipeline we which you don't need for just developing a spider.
 - The argument `since_lastmod` is the earliest sitemap file and page the scraper will include.
 - The last argument `crawl` is the name of the scraper (e.g. `iol`). See output from the previous section.
 

--- a/README.md
+++ b/README.md
@@ -22,35 +22,94 @@ We do not make news content available for public consumption. We simply store an
 
 ### Set up your development environment
 
+#### Clone
+
 Fork this repository on GitHub and clone your fork:
+
 ```bash
-git clone https://github.com/your-name/scrape-news.git
+$ git clone https://github.com/your-name/scrape-news.git
 ```
 or
+
 ```bash
-git clone git@github.com:your-name/scrape-news.git
+$ git clone git@github.com:your-name/scrape-news.git
 ```
+
 (Make sure to replace ```your-name```.)
 
-Create a Python 2 virtual environment for this project inside the cloned project directory (Note: your virtual environment program might not be called `pyvenv` -
-```bash
-cd scrapenews
-pyvenv env
-```
-
-If your default Python is Python3, try `virtualenv` instead; it creates a Python2 environment by default:
-```bash
-cd scrapenews
-virtualenv .env2
-source .env2/bin/activate
-pip install -r requirements.txt
-```
-
-Run a scraper to check that your environment is working properly. The argument `since_lastmod` is the earliest sitemap file and page the scraper will include. The setting `ITEM_PIPELINES` disables the pipeline we have configured which you don't need for just developing a spider.
+Navigate to the repo.
 
 ```bash
-scrapy crawl iol -s ITEM_PIPELINES="{}" -a since_lastmod=2018-04-30
+$ cd <PATH_TO_REPO>
 ```
+
+### Setup virtual environment
+
+1. Create a virtual environment called `venv`.
+    ```bash
+    $ make new-env
+    ```
+2. Activate it.
+    ```bash
+    $ source venv/bin/activate
+    ```
+3. Install main dependencies.
+    ```bash
+    $ make install
+    ```
+4. Install dev dependencies.
+    ```bash
+    $ make dev-install
+    ```
+
+#### Run
+
+Note: Always activate the project's environment before using it.
+
+```bash
+$ source venv/bin/activate
+```
+
+##### List available spiders in the project
+
+
+```bash
+$ make list
+scrapenews/utils/list_spiders.py # This is script you just ran.
+businesslivecrawl
+businesslivesitemap
+dailymaverick
+dailyvoice
+dfa
+dispatchlive
+enca
+ewn
+groundup
+iol
+mg
+news24
+rekordnorth
+sabc
+sowetanlive
+thenewage
+timeslive
+```
+
+We will use these crawler names in the next step. Note that these names are generated from _classes_ in the [spiders](/scrapenews/spiders/) directory and not the _filenames_.
+
+##### Run scraper
+
+Run a scraper using the command below to check that your environment is working properly. Note that this _can_ be done from the root directory because of how the `scrapy` library works.
+
+```bash
+$ scrapy crawl iol -s ITEM_PIPELINES="{}" -a since_lastmod=2018-04-30
+```
+
+- The argument following `crawl` is the name of the scraper (e.g. `iol`). See output from the previous section.
+- The setting `ITEM_PIPELINES` disables the pipeline we have configured which you don't need for just developing a spider.
+- The argument `since_lastmod` is the earliest sitemap file and page the scraper will include.
+
+##### Output
 
 If it's working correctly, it will output a lot of information:
 
@@ -94,7 +153,7 @@ Public People needs the following fields:
 | retrieved_at | ISO 8601 date of current date/time to know when we scraped it. |
 | spider_name | Generally the module name. |
 | title | Article title. |
-| url | This is used as the unique identifier for this article for deduplication, so use the [canonical url meta tag value](https://yoast.com/rel-canonical/) if available, otherwise just try to parse out the unique part of the URL from `resposne.url` and exclude things like query string paramaters and URL fragment  identifier. |
+| url | This is used as the unique identifier for this article for deduplication, so use the [canonical url meta tag value](https://yoast.com/rel-canonical/) if available, otherwise just try to parse out the unique part of the URL from `response.url` and exclude things like query string parameters and URL fragment  identifier. |
 
 First, add this repository as a remote and make sure your local master is up to date:
 ```bash
@@ -121,14 +180,19 @@ Copy a spider from the repository and amend it as necessary: a good example of a
 ### Test your responses
 
 To test individual xpath or css responses you can use the scrapy shell:
+
 ```bash
 scrapy shell "https://www.newssite.co.za/article-url"
 ```
-If you go to the same url in your browser and right-click on, say, the title of the article, and select 'Inspect Element (Q)', you'll see something like
+
+If you go to the same url in your browser and right-click on, say, the title of the article, and select 'Inspect Element (Q)', you'll see something like this highlighted.
+
 ```html
 <h1 class="article-title">Title of article</h1>
 ```
-highlighted. In the scrapy shell you can then enter
+
+In the scrapy, shell you can then enter
+
 ```bash
 >>> response.css('h1.article-title').xpath('text()').extract_first()
 ```
@@ -235,7 +299,7 @@ SitemapSpider scrapers can run daily, fetching only the latest articles. Crawlin
 
 Tunnel a connection to the server if you're not scheduling it from the server:
 
-```
+```bash
 ssh -L 6800:localhost:6800 username@hostname
 ```
 
@@ -243,12 +307,12 @@ ssh -L 6800:localhost:6800 username@hostname
 
 SitemapSpiders take an argument `since_lastmod` which is an ISO format date filtering sitemaps and links in sitemaps. To do a complete scrape, just set it to a date very long ago, like `1900-01-01`.
 
-```
+```bash
 curl -v http://localhost:6800/schedule.json -d project=scrapenews -d spider=iol -d setting=ALEPH_API_KEY=... -d since_lastmod=$(date +%Y-%m-%d -d "5 day ago")
 ```
 
 #### Schedule a crawling spider
 
-```
+```bash
 curl -v http://localhost:6800/schedule.json -d project=scrapenews -d spider=thenewage -d setting=ALEPH_API_KEY=...
 ```

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ $ make test-iol
 
 #### Output
 
-If the crawl command is working correctly, it will output a lot of information.
+If the crawl command above is working correctly, it will output a lot of information:
 
 e.g. after starting up it will find the sitemap and some articles that it will ignore in the sitemaps.
 

--- a/README.md
+++ b/README.md
@@ -107,12 +107,12 @@ We will use these crawler names in the next step. Note that these names are gene
 Run a scraper using the command below to check that your environment is working properly. This can be done from the project root because of how the `scrapy` library works.
 
 ```bash
-$ scrapy crawl iol -s ITEM_PIPELINES="{}" -a since_lastmod=2018-04-30
+$ scrapy crawl -s ITEM_PIPELINES="{}" -a since_lastmod=2018-04-30 iol
 ```
 
-- The argument following `crawl` is the name of the scraper (e.g. `iol`). See output from the previous section.
 - The setting `ITEM_PIPELINES` disables the pipeline we have configured which you don't need for just developing a spider.
 - The argument `since_lastmod` is the earliest sitemap file and page the scraper will include.
+- The last argument `crawl` is the name of the scraper (e.g. `iol`). See output from the previous section.
 
 For quick testing on just this one spider, a shortcut for the above command has been added to the [Makefile](/Makefile). Use it like this:
 
@@ -120,12 +120,20 @@ For quick testing on just this one spider, a shortcut for the above command has 
 $ make test-iol
 ```
 
+Also, if you need to get a template crawl command quickly and then fill in with a crawler, run the following and then copy and paste the result to a new line.
+
+```bash
+$ make test-help
+scrapy crawl -s ITEM_PIPELINES="{}" -a since_lastmod=2018-01-01 <CRAWLER>
+```
+
 #### Output
 
-If it's working correctly, it will output a lot of information:
+If the crawl command is working correctly, it will output a lot of information.
 
-e.g. after starting up it will find the sitemap and some articles that it will ignore in the sitemaps:
+e.g. after starting up it will find the sitemap and some articles that it will ignore in the sitemaps.
 
+Sample output for _iol_ crawler.
 ```
 2018-05-03 18:21:17 [scrapy.core.engine] DEBUG: Crawled (200) <GET https://www.iol.co.za/robots.txt> (referer: None) ['cached']
 2018-05-03 18:21:17 [scrapy.core.engine] DEBUG: Crawled (200) <GET https://www.iol.co.za/sitemap.xml> (referer: https://www.iol.co.za/robots.txt) ['cached']
@@ -135,7 +143,7 @@ e.g. after starting up it will find the sitemap and some articles that it will i
 2018-05-03 18:21:18 [scrapenews.spiders.sitemap] DEBUG: Skipping too old https://www.iol.co.za/personal-finance/six-cappuccinos-or-a-year-off-your-home-loan-14626132
 ```
 
-when it reaches articles that are after the earliest accepted date, it will actually scrape content from the pages and print the resulting [ScrapenewsItem]() for the article
+when it reaches articles that are after the earliest accepted date, it will actually scrape content from the pages and print the resulting [ScrapenewsItem](/scrapenews/items.py) for the article:
 
 ```
 2018-05-03 18:21:34 [scrapy.core.scraper] DEBUG: Scraped from <200 https://www.iol.co.za/personal-finance/stanlib-may-further-reduce-fund-offering-14717297>

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,1 @@
 flake8
-pylint

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 Scrapy==1.8.0
-requests==2.20.0
+requests==2.22.0
 pytz==2019.3
 python-slugify==4.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 Scrapy==1.5.0
 requests==2.20.0
 pytz==2018.3
-slugify==0.0.1
+python-slugify==4.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Scrapy==1.5.0
+Scrapy==1.8.0
 requests==2.20.0
-pytz==2018.3
+pytz==2019.3
 python-slugify==4.0.0

--- a/scrapenews/items.py
+++ b/scrapenews/items.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from __future__ import absolute_import
 import scrapy
 
 

--- a/scrapenews/items.py
+++ b/scrapenews/items.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import absolute_import
 import scrapy
 
 

--- a/scrapenews/lib.py
+++ b/scrapenews/lib.py
@@ -10,7 +10,7 @@ def parse_date_hour_min(value):
     return datetime.datetime.strptime(value.strip()[:16], '%Y-%m-%d %H:%M')
 
 
-def parse_date_hour_min_sec(value):
+def parse_ISO8601_datetime(value):
     """
     Ignore parse datetime string down to seconds, ignoring microseconds.
     """

--- a/scrapenews/lib.py
+++ b/scrapenews/lib.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 import datetime
 
 

--- a/scrapenews/lib.py
+++ b/scrapenews/lib.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 import datetime
 
 

--- a/scrapenews/lib.py
+++ b/scrapenews/lib.py
@@ -1,11 +1,11 @@
 import datetime
 
 
-def parse_date(value):
+def parse_ISO8601_date(value):
     return datetime.datetime.strptime(value.strip()[:10], '%Y-%m-%d')
 
 
-def parse_date_hour_min(value):
+def parse_ISO8601_date_hour_min(value):
     value = value.replace("T", " ")
     return datetime.datetime.strptime(value.strip()[:16], '%Y-%m-%d %H:%M')
 

--- a/scrapenews/lib.py
+++ b/scrapenews/lib.py
@@ -17,3 +17,7 @@ def parse_date_hour_min_sec(value):
     """
     value = value.replace("T", " ")
     return datetime.datetime.strptime(value[:19], '%Y-%m-%d %H:%M:%S')
+
+
+def parse_long_month_hour_min_meridian(value):
+    return datetime.datetime.strptime(value, '%d %B %Y, %I:%M %p')

--- a/scrapenews/lib.py
+++ b/scrapenews/lib.py
@@ -3,12 +3,12 @@ import datetime
 
 
 def parse_date(value):
-    return datetime.datetime.strptime(value[:10], '%Y-%m-%d')
+    return datetime.datetime.strptime(value.strip()[:10], '%Y-%m-%d')
 
 
 def parse_date_hour_min(value):
     value = value.replace("T", " ")
-    return datetime.datetime.strptime(value[:16], '%Y-%m-%d %H:%M')
+    return datetime.datetime.strptime(value.strip()[:16], '%Y-%m-%d %H:%M')
 
 
 def parse_date_hour_min_sec(value):
@@ -16,8 +16,8 @@ def parse_date_hour_min_sec(value):
     Ignore parse datetime string down to seconds, ignoring microseconds.
     """
     value = value.replace("T", " ")
-    return datetime.datetime.strptime(value[:19], '%Y-%m-%d %H:%M:%S')
+    return datetime.datetime.strptime(value.strip()[:19], '%Y-%m-%d %H:%M:%S')
 
 
 def parse_long_month_hour_min_meridian(value):
-    return datetime.datetime.strptime(value, '%d %B %Y, %I:%M %p')
+    return datetime.datetime.strptime(value.strip(), '%d %B %Y, %I:%M %p')

--- a/scrapenews/middlewares.py
+++ b/scrapenews/middlewares.py
@@ -19,6 +19,7 @@ class ScrapenewsSpiderMiddleware(object):
         # This method is used by Scrapy to create your spiders.
         s = cls()
         crawler.signals.connect(s.spider_opened, signal=signals.spider_opened)
+
         return s
 
     def process_spider_input(self, response, spider):
@@ -67,6 +68,7 @@ class ScrapenewsDownloaderMiddleware(object):
         # This method is used by Scrapy to create your spiders.
         s = cls()
         crawler.signals.connect(s.spider_opened, signal=signals.spider_opened)
+
         return s
 
     def process_request(self, request, spider):

--- a/scrapenews/middlewares.py
+++ b/scrapenews/middlewares.py
@@ -5,6 +5,7 @@ Define here the models for your spider middleware
 See documentation in:
 https://doc.scrapy.org/en/latest/topics/spider-middleware.html
 """
+from __future__ import absolute_import
 from scrapy import signals
 
 

--- a/scrapenews/middlewares.py
+++ b/scrapenews/middlewares.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Define here the models for your spider middleware
 

--- a/scrapenews/middlewares.py
+++ b/scrapenews/middlewares.py
@@ -4,7 +4,6 @@ Define here the models for your spider middleware
 See documentation in:
 https://doc.scrapy.org/en/latest/topics/spider-middleware.html
 """
-from __future__ import absolute_import
 from scrapy import signals
 
 

--- a/scrapenews/pipelines.py
+++ b/scrapenews/pipelines.py
@@ -1,12 +1,12 @@
-# -*- coding: utf-8 -*-
-from __future__ import absolute_import
+import json
 import logging
 import requests
-import json
+import six
 from six.moves.urllib.parse import urljoin
+
 from slugify import slugify
 from requests.adapters import HTTPAdapter
-import six
+
 
 logger = logging.getLogger(__name__)
 

--- a/scrapenews/pipelines.py
+++ b/scrapenews/pipelines.py
@@ -1,10 +1,12 @@
 # -*- coding: utf-8 -*-
+from __future__ import absolute_import
 import logging
 import requests
 import json
-from urlparse import urljoin
+from six.moves.urllib.parse import urljoin
 from slugify import slugify
 from requests.adapters import HTTPAdapter
+import six
 
 logger = logging.getLogger(__name__)
 
@@ -46,7 +48,7 @@ class AlephPipeline(object):
             return item
 
         collection_id = self.get_collection_id(
-            slugify(unicode(item['publication_name'])),
+            slugify(six.text_type(item['publication_name'])),
             item['publication_name']
         )
         url = self.make_url('collections/%s/ingest' % collection_id)

--- a/scrapenews/settings.py
+++ b/scrapenews/settings.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Scrapy settings for scrapenews project
 

--- a/scrapenews/spiders/__init__.py
+++ b/scrapenews/spiders/__init__.py
@@ -1,4 +1,6 @@
-# This package will contain the spiders of your Scrapy project
-#
-# Please refer to the documentation for information on how to create and manage
-# your spiders.
+"""
+This package will contain the spiders of your Scrapy project
+
+Please refer to the documentation for information on how to create and manage
+your spiders.
+"""

--- a/scrapenews/spiders/businesslive.py
+++ b/scrapenews/spiders/businesslive.py
@@ -73,7 +73,9 @@ class BusinessLiveSpider(BusinessLiveMixin, SitemapSpider):
     sitemap_urls = ['https://www.businesslive.co.za/sitemap.xml']
     sitemap_follow = ['politics', 'companies', 'people', 'national', 'news',
                       'special-reports', 'economy', 'markets']
-    sitemap_rules = [('.*', 'parse_item')]
+    sitemap_rules = [
+        ('.*', 'parse_item')
+    ]
 
 
 class BusinessLiveCrawlSpider(BusinessLiveMixin, CrawlSpider):

--- a/scrapenews/spiders/businesslive.py
+++ b/scrapenews/spiders/businesslive.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 import pytz
 from datetime import datetime
 

--- a/scrapenews/spiders/businesslive.py
+++ b/scrapenews/spiders/businesslive.py
@@ -34,7 +34,8 @@ class BusinessLiveMixin():
             # join multiple text sections
             body_html = " ".join(article_body.extract())
             byline = response.css('span.heading-author').xpath('text()').extract_first()
-            publication_date_str = response.css('div.article-pub-date').xpath('text()').extract_first().strip()
+            publication_date_str = response.css('div.article-pub-date')\
+                .xpath('text()').extract_first().strip()
             publication_date = datetime.strptime(publication_date_str, '%d %B %Y - %H:%M')
             publication_date = SAST.localize(publication_date)
 
@@ -70,7 +71,8 @@ class BusinessLiveSpider(BusinessLiveMixin, SitemapSpider):
     allowed_domains = ['www.businesslive.co.za']
 
     sitemap_urls = ['https://www.businesslive.co.za/sitemap.xml']
-    sitemap_follow = ['politics', 'companies', 'people', 'national', 'news', 'special-reports', 'economy', 'markets']
+    sitemap_follow = ['politics', 'companies', 'people', 'national', 'news',
+                      'special-reports', 'economy', 'markets']
     sitemap_rules = [('.*', 'parse_item')]
 
 
@@ -83,12 +85,16 @@ class BusinessLiveCrawlSpider(BusinessLiveMixin, CrawlSpider):
         # Extract links containing a date in the url and parse them with the spider's method parse_item
         Rule(LinkExtractor(
             allow=(r'\d{4}-\d{2}-\d{2}',),
-            deny=(r'/(opinion|world|sport|life|multimedia|redzone|technology|popcorn|lifestyle|wsj|sign-up|careers)/',),
+            deny=(
+                r'/(opinion|world|sport|life|multimedia|redzone|technology|popcorn|lifestyle|wsj|sign-up|careers)/',
+            ),
         ), callback='parse_item'),
 
         # Extract links matching these categories and follow links from them
         Rule(LinkExtractor(
             allow=(r'fm|bd|rdm|bt|ft',),
-            deny=(r'/(opinion|world|sport|life|multimedia|redzone|technology|popcorn|lifestyle|wsj|sign-up|careers)/',)
+            deny=(
+                r'/(opinion|world|sport|life|multimedia|redzone|technology|popcorn|lifestyle|wsj|sign-up|careers)/',
+            )
         ), follow=True),
     )

--- a/scrapenews/spiders/businesslive.py
+++ b/scrapenews/spiders/businesslive.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 import pytz
 from datetime import datetime
 

--- a/scrapenews/spiders/dailymaverick.py
+++ b/scrapenews/spiders/dailymaverick.py
@@ -37,7 +37,7 @@ class DailMaverickSpider(SitemapSpider):
             byline = response.xpath('//meta[@name="author"]/@content').extract_first()
             publication_date_str = response.xpath('//meta[@name="published"]/@content').extract_first()
 
-            publication_date = lib.parse_date(publication_date_str)
+            publication_date = lib.parse_ISO8601_date(publication_date_str)
             publication_date = SAST.localize(publication_date)
 
             item = ScrapenewsItem()

--- a/scrapenews/spiders/dailymaverick.py
+++ b/scrapenews/spiders/dailymaverick.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import absolute_import
 import pytz
 from datetime import datetime
 

--- a/scrapenews/spiders/dailymaverick.py
+++ b/scrapenews/spiders/dailymaverick.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from __future__ import absolute_import
 import pytz
 from datetime import datetime
 

--- a/scrapenews/spiders/dailyvoice.py
+++ b/scrapenews/spiders/dailyvoice.py
@@ -65,7 +65,7 @@ class DailyvoiceSpider(CrawlSpider):
             # Date format changes, previously it was:
             #   '18 June 2018, 09:01am'
             #   '%d %B %Y, %I:%M%p'
-            publication_date = lib.parse_date_hour_min_sec(publication_date_str)
+            publication_date = lib.parse_ISO8601_datetime(publication_date_str)
             publication_date = SAST.localize(publication_date)
 
             if body_html:

--- a/scrapenews/spiders/dailyvoice.py
+++ b/scrapenews/spiders/dailyvoice.py
@@ -67,14 +67,13 @@ class DailyvoiceSpider(CrawlSpider):
             #   '%d %B %Y, %I:%M%p'
             publication_date = lib.parse_date_hour_min_sec(publication_date_str)
             publication_date = SAST.localize(publication_date)
-            published_at = publication_date.isoformat()
 
             if body_html:
                 item = ScrapenewsItem()
                 item['body_html'] = body_html
                 item['title'] = title
                 item['byline'] = byline
-                item['published_at'] = published_at
+                item['published_at'] = publication_date.isoformat()
                 item['retrieved_at'] = datetime.utcnow().isoformat()
                 item['url'] = canonical_url
                 item['file_name'] = response.url.split('/')[-1]

--- a/scrapenews/spiders/dailyvoice.py
+++ b/scrapenews/spiders/dailyvoice.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import absolute_import
 import pytz
 from datetime import datetime
 

--- a/scrapenews/spiders/dailyvoice.py
+++ b/scrapenews/spiders/dailyvoice.py
@@ -10,6 +10,14 @@ from scrapenews.items import ScrapenewsItem
 
 SAST = pytz.timezone('Africa/Johannesburg')
 
+IGNORE_URLS = {
+    'https://www.dailyvoice.co.za/news/business',
+    'https://www.dailyvoice.co.za/news/international',
+    'https://www.dailyvoice.co.za/news/national',
+    'https://www.dailyvoice.co.za/news/politics',
+    'https://www.dailyvoice.co.za/news/western-cape',
+}
+
 
 class DailyvoiceSpider(CrawlSpider):
     name = 'dailyvoice'
@@ -87,21 +95,8 @@ class DailyvoiceSpider(CrawlSpider):
             elif '/news/international/' in link.url:
                 self.logger.info("Ignoring %s", link.url)
                 continue
-            elif link.url == 'https://www.dailyvoice.co.za/news/business':
+            elif link.url in IGNORE_URLS:
                 self.logger.info("Ignoring %s", link.url)
                 continue
-            elif link.url == 'https://www.dailyvoice.co.za/news/international':
-                self.logger.info("Ignoring %s", link.url)
-                continue
-            elif link.url == 'https://www.dailyvoice.co.za/news/national':
-                self.logger.info("Ignoring %s", link.url)
-                continue
-            elif link.url == 'https://www.dailyvoice.co.za/news/politics':
-                self.logger.info("Ignoring %s", link.url)
-                continue
-            elif link.url == 'https://www.dailyvoice.co.za/news/western-cape':
-                self.logger.info("Ignoring %s", link.url)
-                continue
-            # I'm assuming the above can be simplified but it works!
             else:
                 yield link

--- a/scrapenews/spiders/dailyvoice.py
+++ b/scrapenews/spiders/dailyvoice.py
@@ -62,8 +62,8 @@ class DailyvoiceSpider(CrawlSpider):
             byline = response.xpath('//strong[@itemprop="name"]/text()').extract_first()
             publication_date_str = response.xpath('//meta[@itemprop="datePublished"]/@content').extract_first()
 
-            # Previously:
-            #   u'18 June 2018, 09:01am' -- also tested with '8 June 2018, 09:20pm'
+            # Date format changes, previously it was:
+            #   '18 June 2018, 09:01am'
             #   '%d %B %Y, %I:%M%p'
             publication_date = lib.parse_date_hour_min_sec(publication_date_str)
             publication_date = SAST.localize(publication_date)

--- a/scrapenews/spiders/dailyvoice.py
+++ b/scrapenews/spiders/dailyvoice.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from __future__ import absolute_import
 import pytz
 from datetime import datetime
 

--- a/scrapenews/spiders/dailyvoice.py
+++ b/scrapenews/spiders/dailyvoice.py
@@ -1,10 +1,12 @@
 # -*- coding: utf-8 -*-
+import pytz
+from datetime import datetime
 
 from scrapy.spiders import CrawlSpider, Rule
 from scrapy.linkextractors import LinkExtractor
+
 from scrapenews.items import ScrapenewsItem
-from datetime import datetime
-import pytz
+
 
 SAST = pytz.timezone('Africa/Johannesburg')
 

--- a/scrapenews/spiders/dfa.py
+++ b/scrapenews/spiders/dfa.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import absolute_import
 import pytz
 from datetime import datetime
 

--- a/scrapenews/spiders/dfa.py
+++ b/scrapenews/spiders/dfa.py
@@ -56,7 +56,7 @@ class dfaSpider(CrawlSpider):
 
             publication_date_str = response.xpath('//time/@datetime').extract_first()
             # u'2018-06-14T11:00:00+00:00'
-            publication_date = lib.parse_date_hour_min_sec(publication_date_str)
+            publication_date = lib.parse_ISO8601_datetime(publication_date_str)
             # datetime.datetime(2018, 6, 14, 11, 0)
             publication_date = SAST.localize(publication_date)
             # datetime.datetime(2018, 6, 14, 11, 0, tzinfo=<DstTzInfo 'Africa/Johannesburg' SAST+2:00:00 STD>)

--- a/scrapenews/spiders/dfa.py
+++ b/scrapenews/spiders/dfa.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from __future__ import absolute_import
 import pytz
 from datetime import datetime
 

--- a/scrapenews/spiders/dispatchlive.py
+++ b/scrapenews/spiders/dispatchlive.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import absolute_import
 import pytz
 from datetime import datetime
 

--- a/scrapenews/spiders/dispatchlive.py
+++ b/scrapenews/spiders/dispatchlive.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from __future__ import absolute_import
 import pytz
 from datetime import datetime
 

--- a/scrapenews/spiders/dispatchlive.py
+++ b/scrapenews/spiders/dispatchlive.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
-
-from .sitemap import SitemapSpider
-from scrapenews.items import ScrapenewsItem
-from datetime import datetime
 import pytz
+from datetime import datetime
+
+from scrapenews.items import ScrapenewsItem
+from .sitemap import SitemapSpider
 
 SAST = pytz.timezone('Africa/Johannesburg')
 

--- a/scrapenews/spiders/enca.py
+++ b/scrapenews/spiders/enca.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import absolute_import
 from datetime import datetime
 
 from scrapy.spiders import CrawlSpider, Rule

--- a/scrapenews/spiders/enca.py
+++ b/scrapenews/spiders/enca.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from __future__ import absolute_import
 from datetime import datetime
 
 from scrapy.spiders import CrawlSpider, Rule

--- a/scrapenews/spiders/ewn.py
+++ b/scrapenews/spiders/ewn.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import absolute_import
 import pytz
 from datetime import datetime
 

--- a/scrapenews/spiders/ewn.py
+++ b/scrapenews/spiders/ewn.py
@@ -41,7 +41,7 @@ class ewnSpider(CrawlSpider):
 
             publication_date_str = response.xpath('//meta[@itemprop="datePublished"]/@content').extract_first()
             # alas no time portion: possibly use timelib to
-            publication_date = lib.parse_date(publication_date_str)
+            publication_date = lib.parse_ISO8601_date(publication_date_str)
             # datetime.datetime(2018, 6, 14, 11, 0)
             publication_date = SAST.localize(publication_date)
             # datetime.datetime(2018, 6, 14, 11, 0, tzinfo=<DstTzInfo 'Africa/Johannesburg' SAST+2:00:00 STD>)

--- a/scrapenews/spiders/ewn.py
+++ b/scrapenews/spiders/ewn.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from __future__ import absolute_import
 import pytz
 from datetime import datetime
 

--- a/scrapenews/spiders/groundup.py
+++ b/scrapenews/spiders/groundup.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import absolute_import
 import pytz
 from datetime import datetime
 

--- a/scrapenews/spiders/groundup.py
+++ b/scrapenews/spiders/groundup.py
@@ -43,8 +43,10 @@ class groundupSpider(CrawlSpider):
 
         if og_type == 'article':
             subtitle = response.xpath('//p[@id="article_subtitle"]').css('::text').extract_first()
-            photo_caption = response.xpath('//figcaption[@id="article_primary_image_caption"]/text()').extract_first()
+            photo_caption = response.xpath('//figcaption[@id="article_primary_image_caption"]/text()')\
+                .extract_first()
             article_body = " ".join(response.xpath('//div[@id="article_body"]').css('::text').extract())
+
             if subtitle and photo_caption:
                 body_html = subtitle + photo_caption + article_body
             elif subtitle and not photo_caption:
@@ -53,6 +55,7 @@ class groundupSpider(CrawlSpider):
                 body_html = photo_caption + article_body
             else:
                 body_html = article_body
+
             byline = response.xpath('//a[@rel="author"]/text()').extract_first()
             publication_date_str = response.xpath('//time/@datetime').extract_first()
             publication_date = lib.parse_date(publication_date_str)

--- a/scrapenews/spiders/groundup.py
+++ b/scrapenews/spiders/groundup.py
@@ -57,7 +57,7 @@ class groundupSpider(CrawlSpider):
 
             byline = response.xpath('//a[@rel="author"]/text()').extract_first()
             publication_date_str = response.xpath('//time/@datetime').extract_first()
-            publication_date = lib.parse_date(publication_date_str)
+            publication_date = lib.parse_ISO8601_date(publication_date_str)
             publication_date = SAST.localize(publication_date)
 
             if body_html:

--- a/scrapenews/spiders/groundup.py
+++ b/scrapenews/spiders/groundup.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from __future__ import absolute_import
 import pytz
 from datetime import datetime
 

--- a/scrapenews/spiders/iol.py
+++ b/scrapenews/spiders/iol.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import absolute_import
 import pytz
 from datetime import datetime
 

--- a/scrapenews/spiders/iol.py
+++ b/scrapenews/spiders/iol.py
@@ -32,7 +32,7 @@ class IOLSpider(SitemapSpider):
             byline = response.xpath('//span[@itemprop="author"]/strong/text()').extract_first()
             publication_date_str = response.xpath('//span[@itemprop="datePublished"]/@content').extract_first()
 
-            publication_date = lib.parse_date_hour_min(publication_date_str)
+            publication_date = lib.parse_ISO8601_date_hour_min(publication_date_str)
             publication_date = SAST.localize(publication_date)
 
             item = ScrapenewsItem()

--- a/scrapenews/spiders/iol.py
+++ b/scrapenews/spiders/iol.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from __future__ import absolute_import
 import pytz
 from datetime import datetime
 

--- a/scrapenews/spiders/iol.py
+++ b/scrapenews/spiders/iol.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
-from datetime import datetime
 import pytz
+from datetime import datetime
 
 from scrapenews import lib
 from scrapenews.items import ScrapenewsItem

--- a/scrapenews/spiders/mg.py
+++ b/scrapenews/spiders/mg.py
@@ -1,10 +1,11 @@
 # -*- coding: utf-8 -*-
-
-from .sitemap import SitemapSpider
-from scrapenews.items import ScrapenewsItem
-from datetime import datetime
 import pytz
+from datetime import datetime
 from w3lib.html import remove_tags
+
+from scrapenews.items import ScrapenewsItem
+from .sitemap import SitemapSpider
+
 
 SAST = pytz.timezone('Africa/Johannesburg')
 

--- a/scrapenews/spiders/mg.py
+++ b/scrapenews/spiders/mg.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import absolute_import
 import pytz
 from datetime import datetime
 from w3lib.html import remove_tags

--- a/scrapenews/spiders/mg.py
+++ b/scrapenews/spiders/mg.py
@@ -61,7 +61,7 @@ class MGSpider(SitemapSpider):
         body_text = remove_tags(body_html, encoding='utf-8')
         for string in SKIP_STRINGS:
             suffix = body_text[-20:]
-            if string in suffix:
+            if six.text_type(string) in suffix:
                 self.logger.info(
                     "Skipping %s because suffix %r contains %r",
                     canonical_url, suffix, string

--- a/scrapenews/spiders/mg.py
+++ b/scrapenews/spiders/mg.py
@@ -61,7 +61,7 @@ class MGSpider(SitemapSpider):
         body_text = remove_tags(body_html, encoding='utf-8')
         for string in SKIP_STRINGS:
             suffix = body_text[-20:]
-            if six.text_type(string, 'utf-8') in suffix:
+            if string in suffix:
                 self.logger.info(
                     "Skipping %s because suffix %r contains %r",
                     canonical_url, suffix, string

--- a/scrapenews/spiders/mg.py
+++ b/scrapenews/spiders/mg.py
@@ -62,10 +62,10 @@ class MGSpider(SitemapSpider):
         for string in SKIP_STRINGS:
             suffix = body_text[-20:]
             if unicode(string, 'utf-8') in suffix:
-                self.logger.info("Skipping %s because suffix %r contains %r",
-                                 canonical_url,
-                                 suffix,
-                                 string)
+                self.logger.info(
+                    "Skipping %s because suffix %r contains %r",
+                    canonical_url, suffix, string
+                )
                 return
 
         publication_date_str = response.xpath('//meta[@name="publicationdate"]/@content').extract_first()

--- a/scrapenews/spiders/mg.py
+++ b/scrapenews/spiders/mg.py
@@ -1,10 +1,12 @@
 # -*- coding: utf-8 -*-
+from __future__ import absolute_import
 import pytz
 from datetime import datetime
 from w3lib.html import remove_tags
 
 from scrapenews.items import ScrapenewsItem
 from .sitemap import SitemapSpider
+import six
 
 
 SAST = pytz.timezone('Africa/Johannesburg')
@@ -61,7 +63,7 @@ class MGSpider(SitemapSpider):
         body_text = remove_tags(body_html, encoding='utf-8')
         for string in SKIP_STRINGS:
             suffix = body_text[-20:]
-            if unicode(string, 'utf-8') in suffix:
+            if six.text_type(string, 'utf-8') in suffix:
                 self.logger.info(
                     "Skipping %s because suffix %r contains %r",
                     canonical_url, suffix, string

--- a/scrapenews/spiders/news24.py
+++ b/scrapenews/spiders/news24.py
@@ -59,4 +59,5 @@ class News24Spider(SitemapSpider):
                 item['publication_name'] += " with " + accreditation[1:]
 
             yield item
+
         self.logger.info("")

--- a/scrapenews/spiders/news24.py
+++ b/scrapenews/spiders/news24.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import absolute_import
 import pytz
 from datetime import datetime
 

--- a/scrapenews/spiders/news24.py
+++ b/scrapenews/spiders/news24.py
@@ -40,7 +40,7 @@ class News24Spider(SitemapSpider):
                 '//div[contains(@class, "ByLineWidth")]/div[contains(@class, "accreditation")]/a/@href'
             ).extract_first()
 
-            publication_date = lib.parse_date(publication_date_str)
+            publication_date = lib.parse_ISO8601_date(publication_date_str)
             publication_date = SAST.localize(publication_date)
 
             item = ScrapenewsItem()

--- a/scrapenews/spiders/news24.py
+++ b/scrapenews/spiders/news24.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from __future__ import absolute_import
 import pytz
 from datetime import datetime
 

--- a/scrapenews/spiders/rekordnorth.py
+++ b/scrapenews/spiders/rekordnorth.py
@@ -49,7 +49,7 @@ class dfaSpider(CrawlSpider):
 
             publication_date_str = response.xpath('//time/@datetime').extract_first()
             # u'2018-06-14T11:00:00+00:00'
-            publication_date = lib.parse_date_hour_min_sec(publication_date_str)
+            publication_date = lib.parse_ISO8601_datetime(publication_date_str)
             # datetime.datetime(2018, 6, 14, 11, 0)
             publication_date = SAST.localize(publication_date)
             # datetime.datetime(2018, 6, 14, 11, 0, tzinfo=<DstTzInfo 'Africa/Johannesburg' SAST+2:00:00 STD>)

--- a/scrapenews/spiders/rekordnorth.py
+++ b/scrapenews/spiders/rekordnorth.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import absolute_import
 import pytz
 from datetime import datetime
 

--- a/scrapenews/spiders/rekordnorth.py
+++ b/scrapenews/spiders/rekordnorth.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from __future__ import absolute_import
 import pytz
 from datetime import datetime
 

--- a/scrapenews/spiders/sabc.py
+++ b/scrapenews/spiders/sabc.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import absolute_import
 import pytz
 from datetime import datetime
 

--- a/scrapenews/spiders/sabc.py
+++ b/scrapenews/spiders/sabc.py
@@ -6,6 +6,7 @@ from datetime import datetime
 from scrapy.spiders import CrawlSpider, Rule
 from scrapy.linkextractors import LinkExtractor
 
+from scrapenews import lib
 from scrapenews.items import ScrapenewsItem
 
 
@@ -48,8 +49,10 @@ class sabcSpider(CrawlSpider):
             article_body = response.css('div.post-content')
             body_html = " ".join(article_body.css('::text').extract())
             byline = response.css('span.author::text').extract_first().strip()
-            publication_date_str = response.css('span.create::text').extract_first().strip()
-            publication_date = datetime.strptime(publication_date_str, '%d %B %Y, %I:%M %p')
+
+            # Ignore the first line which is a comment.
+            publication_date_str = response.xpath('//span[@class="create"]/text()').extract()[1]
+            publication_date = lib.parse_long_month_hour_min_meridian(publication_date_str)
             publication_date = SAST.localize(publication_date)
 
             if body_html:

--- a/scrapenews/spiders/sabc.py
+++ b/scrapenews/spiders/sabc.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from __future__ import absolute_import
 import pytz
 from datetime import datetime
 

--- a/scrapenews/spiders/sabc.py
+++ b/scrapenews/spiders/sabc.py
@@ -1,10 +1,12 @@
 # -*- coding: utf-8 -*-
+import pytz
+from datetime import datetime
 
 from scrapy.spiders import CrawlSpider, Rule
 from scrapy.linkextractors import LinkExtractor
+
 from scrapenews.items import ScrapenewsItem
-from datetime import datetime
-import pytz
+
 
 SAST = pytz.timezone('Africa/Johannesburg')
 

--- a/scrapenews/spiders/sitemap.py
+++ b/scrapenews/spiders/sitemap.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 import logging
 
 import scrapy

--- a/scrapenews/spiders/sitemap.py
+++ b/scrapenews/spiders/sitemap.py
@@ -1,7 +1,9 @@
+import logging
+
 import scrapy
 from scrapy.utils.sitemap import Sitemap, sitemap_urls_from_robots
 from scrapy.http import Request
-import logging
+
 
 logger = logging.getLogger(__name__)
 

--- a/scrapenews/spiders/sitemap.py
+++ b/scrapenews/spiders/sitemap.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 import logging
 
 import scrapy

--- a/scrapenews/spiders/sowetanlive.py
+++ b/scrapenews/spiders/sowetanlive.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import absolute_import
 import pytz
 from datetime import datetime
 

--- a/scrapenews/spiders/sowetanlive.py
+++ b/scrapenews/spiders/sowetanlive.py
@@ -1,9 +1,10 @@
 # -*- coding: utf-8 -*-
-
-from .sitemap import SitemapSpider
-from scrapenews.items import ScrapenewsItem
-from datetime import datetime
 import pytz
+from datetime import datetime
+
+from scrapenews.items import ScrapenewsItem
+from .sitemap import SitemapSpider
+
 
 SAST = pytz.timezone('Africa/Johannesburg')
 

--- a/scrapenews/spiders/sowetanlive.py
+++ b/scrapenews/spiders/sowetanlive.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from __future__ import absolute_import
 import pytz
 from datetime import datetime
 

--- a/scrapenews/spiders/thenewage.py
+++ b/scrapenews/spiders/thenewage.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import absolute_import
 import re
 from datetime import datetime
 

--- a/scrapenews/spiders/thenewage.py
+++ b/scrapenews/spiders/thenewage.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from __future__ import absolute_import
 import re
 from datetime import datetime
 

--- a/scrapenews/spiders/thenewage.py
+++ b/scrapenews/spiders/thenewage.py
@@ -12,7 +12,7 @@ from scrapenews.items import ScrapenewsItem
 class ThenewageSpider(CrawlSpider):
     name = 'thenewage'
     allowed_domains = ['www.thenewage.co.za']
-    start_urls = ['http://www.thenewage.co.za/']
+    start_urls = ['https://thenewage.co.za/']
 
     link_extractor = LinkExtractor(allow=())
     rules = (

--- a/scrapenews/spiders/timeslive.py
+++ b/scrapenews/spiders/timeslive.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import absolute_import
 import pytz
 from datetime import datetime
 

--- a/scrapenews/spiders/timeslive.py
+++ b/scrapenews/spiders/timeslive.py
@@ -29,6 +29,7 @@ class TimesliveSpider(SitemapSpider):
 
         title = response.xpath('//h1/span/text()').extract_first()
         self.logger.info('%s %s', response.url, title)
+
         article_body = response.css('div.article-widget-text')
         if article_body:
             # join multiple text sections

--- a/scrapenews/spiders/timeslive.py
+++ b/scrapenews/spiders/timeslive.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from __future__ import absolute_import
 import pytz
 from datetime import datetime
 

--- a/scrapenews/spiders/timeslive.py
+++ b/scrapenews/spiders/timeslive.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
-
-from .sitemap import SitemapSpider
-from scrapenews.items import ScrapenewsItem
-from datetime import datetime
 import pytz
+from datetime import datetime
+
+from scrapenews.items import ScrapenewsItem
+from .sitemap import SitemapSpider
 
 SAST = pytz.timezone('Africa/Johannesburg')
 

--- a/scrapenews/tests/unit/test_lib.py
+++ b/scrapenews/tests/unit/test_lib.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 import datetime
 from unittest import TestCase
 

--- a/scrapenews/tests/unit/test_lib.py
+++ b/scrapenews/tests/unit/test_lib.py
@@ -6,38 +6,38 @@ import lib
 
 class TestLib(TestCase):
 
-    def test_parse_date(self):
+    def test_parse_ISO8601_date(self):
         publication_date_str = "2019-11-22T09:10:11.000Z"
-        result = lib.parse_date(publication_date_str)
+        result = lib.parse_ISO8601_date(publication_date_str)
         self.assertEqual(result, datetime.datetime(2019, 11, 22))
 
         publication_date_str = "2019-11-22 09:10:11.000Z"
-        result = lib.parse_date(publication_date_str)
+        result = lib.parse_ISO8601_date(publication_date_str)
         self.assertEqual(result, datetime.datetime(2019, 11, 22))
 
         publication_date_str = "2019-11-22"
-        result = lib.parse_date(publication_date_str)
+        result = lib.parse_ISO8601_date(publication_date_str)
         self.assertEqual(result, datetime.datetime(2019, 11, 22))
 
         publication_date_str = "\t 2019-11-22T09:10:11.000Z \t"
-        result = lib.parse_date(publication_date_str)
+        result = lib.parse_ISO8601_date(publication_date_str)
         self.assertEqual(result, datetime.datetime(2019, 11, 22))
 
-    def test_parse_date_hour_min(self):
+    def test_parse_ISO8601_date_hour_min(self):
         publication_date_str = "2019-11-22T09:10:11.000Z"
-        result = lib.parse_date_hour_min(publication_date_str)
+        result = lib.parse_ISO8601_date_hour_min(publication_date_str)
         self.assertEqual(result, datetime.datetime(2019, 11, 22, 9, 10))
 
         publication_date_str = "2019-11-22 09:10:11.000Z"
-        result = lib.parse_date_hour_min(publication_date_str)
+        result = lib.parse_ISO8601_date_hour_min(publication_date_str)
         self.assertEqual(result, datetime.datetime(2019, 11, 22, 9, 10))
 
         publication_date_str = "2019-11-22T09:10"
-        result = lib.parse_date_hour_min(publication_date_str)
+        result = lib.parse_ISO8601_date_hour_min(publication_date_str)
         self.assertEqual(result, datetime.datetime(2019, 11, 22, 9, 10))
 
         publication_date_str = "2019-11-22 09:10"
-        result = lib.parse_date_hour_min(publication_date_str)
+        result = lib.parse_ISO8601_date_hour_min(publication_date_str)
         self.assertEqual(result, datetime.datetime(2019, 11, 22, 9, 10))
 
     def test_parse_ISO8601_datetime(self):

--- a/scrapenews/tests/unit/test_lib.py
+++ b/scrapenews/tests/unit/test_lib.py
@@ -20,6 +20,10 @@ class TestLib(TestCase):
         result = lib.parse_date(publication_date_str)
         self.assertEqual(result, datetime.datetime(2019, 11, 22))
 
+        publication_date_str = "\t 2019-11-22T09:10:11.000Z \t"
+        result = lib.parse_date(publication_date_str)
+        self.assertEqual(result, datetime.datetime(2019, 11, 22))
+
     def test_parse_date_hour_min(self):
         publication_date_str = "2019-11-22T09:10:11.000Z"
         result = lib.parse_date_hour_min(publication_date_str)

--- a/scrapenews/tests/unit/test_lib.py
+++ b/scrapenews/tests/unit/test_lib.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 import datetime
 from unittest import TestCase
 

--- a/scrapenews/tests/unit/test_lib.py
+++ b/scrapenews/tests/unit/test_lib.py
@@ -49,3 +49,12 @@ class TestLib(TestCase):
         publication_date_str = "2019-11-22 09:10:00"
         result = lib.parse_date_hour_min_sec(publication_date_str)
         self.assertEqual(result, datetime.datetime(2019, 11, 22, 9, 10, 0))
+
+    def test_parse_long_date_time(self):
+        publication_date_str = "27 November 2019, 6:43 PM"
+        result = lib.parse_long_month_hour_min_meridian(publication_date_str)
+        self.assertEqual(result, datetime.datetime(2019, 11, 27, 18, 43, 0))
+
+        publication_date_str = "3 April 2000, 1:22 AM"
+        result = lib.parse_long_month_hour_min_meridian(publication_date_str)
+        self.assertEqual(result, datetime.datetime(2000, 4, 3, 1, 22, 0))

--- a/scrapenews/tests/unit/test_lib.py
+++ b/scrapenews/tests/unit/test_lib.py
@@ -40,17 +40,17 @@ class TestLib(TestCase):
         result = lib.parse_date_hour_min(publication_date_str)
         self.assertEqual(result, datetime.datetime(2019, 11, 22, 9, 10))
 
-    def test_parse_date_hour_min_sec(self):
+    def test_parse_ISO8601_datetime(self):
         publication_date_str = "2019-11-22T09:10:11.000Z"
-        result = lib.parse_date_hour_min_sec(publication_date_str)
+        result = lib.parse_ISO8601_datetime(publication_date_str)
         self.assertEqual(result, datetime.datetime(2019, 11, 22, 9, 10, 11))
 
         publication_date_str = "2019-11-22T09:10:00"
-        result = lib.parse_date_hour_min_sec(publication_date_str)
+        result = lib.parse_ISO8601_datetime(publication_date_str)
         self.assertEqual(result, datetime.datetime(2019, 11, 22, 9, 10, 0))
 
         publication_date_str = "2019-11-22 09:10:00"
-        result = lib.parse_date_hour_min_sec(publication_date_str)
+        result = lib.parse_ISO8601_datetime(publication_date_str)
         self.assertEqual(result, datetime.datetime(2019, 11, 22, 9, 10, 0))
 
     def test_parse_long_date_time(self):

--- a/scrapenews/tests/unit/test_pipelines.py
+++ b/scrapenews/tests/unit/test_pipelines.py
@@ -1,0 +1,12 @@
+from unittest import TestCase
+
+from pipelines import AlephPipeline
+
+
+class TestPipeline(TestCase):
+
+    def test_AlephPipeline(self):
+        key = '1234'
+        host = 'https://example.com'
+
+        aleph = AlephPipeline(key, host)

--- a/scrapenews/tests/unit/test_spiders.py
+++ b/scrapenews/tests/unit/test_spiders.py
@@ -1,0 +1,19 @@
+"""
+Test spiders.
+
+Light testing to ensure that the syntax of the spiders is correct by loading
+each spider class from the spider modules. Methods are not tested.
+"""
+from __future__ import absolute_import
+from unittest import TestCase
+
+
+from utils import list_spiders
+
+
+class TestSpiders(TestCase):
+
+    def test_names(self):
+        spiders = list_spiders.get_spiders()
+
+        self.assertTrue(len(spiders.keys()) > 0)

--- a/scrapenews/tests/unit/test_spiders.py
+++ b/scrapenews/tests/unit/test_spiders.py
@@ -4,7 +4,6 @@ Test spiders.
 Light testing to ensure that the syntax of the spiders is correct by loading
 each spider class from the spider modules. Methods are not tested.
 """
-from __future__ import absolute_import
 from unittest import TestCase
 
 

--- a/scrapenews/utils/list_spiders.py
+++ b/scrapenews/utils/list_spiders.py
@@ -16,7 +16,7 @@ def get_spiders():
     return {name: spider_loader.load(name) for name in sorted(names)}
 
 
-def test():
+def print_table():
     spiders = get_spiders()
 
     print("Name                 |  Class")
@@ -25,5 +25,12 @@ def test():
         print("{:20} | {}".format(k, v.__name__))
 
 
+def print_list():
+    spiders = get_spiders()
+
+    for k in sorted(spiders.keys()):
+        print(k)
+
+
 if __name__ == '__main__':
-    test()
+    print_list()

--- a/scrapenews/utils/list_spiders.py
+++ b/scrapenews/utils/list_spiders.py
@@ -6,6 +6,7 @@ Based on:
     https://stackoverflow.com/questions/46871133/get-all-spiders-class-name-in-scrapy/46871206
 """
 from __future__ import print_function
+from __future__ import absolute_import
 from scrapy import spiderloader
 from scrapy.utils import project
 

--- a/scrapenews/utils/list_spiders.py
+++ b/scrapenews/utils/list_spiders.py
@@ -5,8 +5,6 @@ List available spiders as names and classes.
 Based on:
     https://stackoverflow.com/questions/46871133/get-all-spiders-class-name-in-scrapy/46871206
 """
-from __future__ import print_function
-from __future__ import absolute_import
 from scrapy import spiderloader
 from scrapy.utils import project
 

--- a/scrapenews/utils/list_spiders.py
+++ b/scrapenews/utils/list_spiders.py
@@ -1,6 +1,9 @@
 #!/usr/bin/env python
 """
 List available spiders as names and classes.
+
+Based on:
+    https://stackoverflow.com/questions/46871133/get-all-spiders-class-name-in-scrapy/46871206
 """
 from __future__ import print_function
 from scrapy import spiderloader

--- a/scrapenews/utils/list_spiders.py
+++ b/scrapenews/utils/list_spiders.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python
+"""
+List available spiders as names and classes.
+"""
+from __future__ import print_function
+from scrapy import spiderloader
+from scrapy.utils import project
+
+
+def get_spiders():
+    settings = project.get_project_settings()
+    spider_loader = spiderloader.SpiderLoader.from_settings(settings)
+
+    names = spider_loader.list()
+
+    return {name: spider_loader.load(name) for name in sorted(names)}
+
+
+def test():
+    spiders = get_spiders()
+
+    print("Name                 |  Class")
+    print("---------------------+-------")
+    for k, v in spiders.items():
+        print("{:20} | {}".format(k, v.__name__))
+
+
+if __name__ == '__main__':
+    test()


### PR DESCRIPTION
# Changes

The repo has been upgraded to PY3 and can no longer run on PY3. Main changes around that are:

- Main changes are unicode text handling to be done with `six`.
- Replaced PY2-only package with PY3 equivalent.
- Updated doc instructions.

There were some other changes to the repo which make it easier to maintain and to fix some xpath and date parsing bugs. 

All the spiders have been tested by hand using the latest code changes.

The changes are covered in detail below.

## Docs

- Updated README
    * New install instructions.
    * Use of `Makefile` to install and run.
- Cleaned up comments and docstrings.

## Chore

- Created VS Code files - `settings.json`, `.env`.
- Created Github workflow file to run against PY3.5 and latest version.
- Added Makefile for easy use of commands.
- Packages
    * Replaced slugify (PY2) with python-slugify (PY3). The imports are unaffected. However this is a breaking changing meaning we can no longer run on PY2.
    * Upgraded Scrapy and pytz to avoid deprecation warnings.
    * Upgraded requests from 2.20.0 to 2.22.0

## Refactor

- Moved common date logic to lib.
- Simplify ignore logic in `dailyvoice.py`
- Code changes for **PY3** upgrade
    * Removed `encoding` lines no longer needed.
    * Removed __init__.py files except where needed for tests.
    * Added changes from `python-modernize`. See [commit](https://github.com/MichaelCurrin/scrape-news/pull/1/commits/3d0cfdb3a9e2b9a49e8758f1ae0815173dda7ba9). That includesuse of `six` for text handling. The `__future__` imports that were added by the tool were later removed once the complete move was made to PY3.

## Fix

- Corrected xpath parse error in `dailyvoice.py`. `/text()` => `/@content`.
- Corrected spider date parsing to prevent errors.
    * `news24.py` moved to date only.
    * `sabc.py`. It had a multiline date field where the line is a HTML and can be ignored. Hence use of `[1]` to get the second element. 
     * `sabc.py` had a bad xpath. Changed from `'span.create::text'` to `//span[@class="create"]/text()`. Also `.strip` was moved to the date function in `lib.py`.
- Changed The New Age to `https` and removed `www` to prevent `301` codes.

## Feature

- Create `list_spiders.py` utility and added to README and `Makefile`

## Test

- Checks.
    * Added linting with flake8 - see `requirements-dev.txt`, `setup.cfg` and `Makefile`. 
    * Manually reordered imports and wrapped lines for readability and to prevent lint errors.
    * Added unit tests.
    * Added linting and unit tests to the Github workflow.
